### PR TITLE
Add info for conditional loading of module only for author tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,25 @@ meta-ok();
 done-testing;
 ```
 
+
+However, you may want to make this test conditional, only run by the
+author (e.g. by checking the "TEST_AUTHOR" environment variable. Also,
+users will not have to habe Test::META on their system):
+```
+use v6;
+use lib 'lib';
+use Test;
+constant AUTHOR = ?%*ENV<TEST_AUTHOR>; 
+
+if AUTHOR { 
+	require Test::META <&meta-ok>;
+	plan 1;
+	meta-ok;
+	done-testing;
+}
+```
+
+
 ## Description
 
 This provides a simple mechanims for module authors to have some

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ done-testing;
 
 
 However, you may want to make this test conditional, only run by the
-author (e.g. by checking the "TEST_AUTHOR" environment variable. Also,
-users will not have to habe Test::META on their system):
+author (e.g. by checking the "TEST_AUTHOR" environment variable). Also,
+regular users of your module will not need Test::META on their system):
 ```
 use v6;
 use lib 'lib';


### PR DESCRIPTION
Added this to the README:

However, you may want to make this test conditional, only run by the
author (e.g. by checking the "TEST_AUTHOR" environment variable). Also,
regular users of your module will not need Test::META on their system):
```
use v6;
use lib 'lib';
use Test;
constant AUTHOR = ?%*ENV<TEST_AUTHOR>;

if AUTHOR {
    require Test::META <&meta-ok>;
    plan 1;
    meta-ok;
    done-testing;
}
```
