### PR TITLE
Make meta test panda compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,18 @@ regular users of your module will not need Test::META on their system):
 use v6;
 use lib 'lib';
 use Test;
+plan 1;
+
 constant AUTHOR = ?%*ENV<TEST_AUTHOR>; 
 
 if AUTHOR { 
 	require Test::META <&meta-ok>;
-	plan 1;
 	meta-ok;
 	done-testing;
+}
+else {
+     skip-rest "Skipping author test";
+     exit;
 }
 ```
 


### PR DESCRIPTION
The example for conditionally executing the test doesn't work for installation with the current panda version as the test fails with "no tests run".
