### PR TITLE
Use a more established env var in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ done-testing;
 
 
 However, you may want to make this test conditional, only run by the
-author (e.g. by checking the `TEST_AUTHOR` environment variable). Also,
+author (e.g. by checking the `AUTHOR_TESTING` environment variable). Also,
 regular users of your module will not need Test::META on their system):
 ```Perl6
 use v6;
@@ -37,7 +37,7 @@ use lib 'lib';
 use Test;
 plan 1;
 
-constant AUTHOR = ?%*ENV<TEST_AUTHOR>; 
+constant AUTHOR = ?%*ENV<AUTHOR_TESTING>; 
 
 if AUTHOR { 
     require Test::META <&meta-ok>;


### PR DESCRIPTION
Based on Test::When[^1] and Lancaster consensus[^2]

[1] https://github.com/zoffixznet/perl6-Test-When#author
[2] https://github.com/Perl-Toolchain-Gang/toolchain-site/blob/master/lancaster-consensus.md#environment-variables-for-testing-contexts

Fixes #15 