### PR TITLE
Adjust test label for name

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ else {
 }
 ```
 
+If you are running under Travis CI you can set the right environment
+variable in the YAML. One way to do this is like this:
+
+```
+script:
+  - AUTHOR_TESTING=1 prove -v -e "perl6 -Ilib"
+```
+
+Other continuous integration systems will have a similar facility.
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -31,15 +31,16 @@ done-testing;
 However, you may want to make this test conditional, only run by the
 author (e.g. by checking the `AUTHOR_TESTING` environment variable). Also,
 regular users of your module will not need Test::META on their system):
+
 ```Perl6
 use v6;
 use lib 'lib';
 use Test;
 plan 1;
 
-constant AUTHOR = ?%*ENV<AUTHOR_TESTING>; 
+constant AUTHOR = ?%*ENV<AUTHOR_TESTING>;
 
-if AUTHOR { 
+if AUTHOR {
     require Test::META <&meta-ok>;
     meta-ok;
     done-testing;

--- a/lib/Test/META.pm
+++ b/lib/Test/META.pm
@@ -99,7 +99,7 @@ module Test::META:ver<0.0.13>:auth<github:jonathanstowe> {
                     ok check-provides($meta), "'provides' looks sane";
                     ok check-authors($meta), "Optional 'authors' and not 'author'";
                     ok check-license($meta), "License is correct";
-                    ok check-name($meta, :$relaxed-name), "name has a hyphen rather than '::' (if this is intentional please pass :relaxed-name to meta-ok)";
+                    ok check-name($meta, :$relaxed-name), "name has a '::' rather than a hyphen (if this is intentional please pass :relaxed-name to meta-ok)";
                     # this is transitional as the method changed in META6
                     ok ($meta.?meta6 | $meta.?meta-version ) ~~ Version.new(0) ?? True !! $seen-vee == 0, "no 'v' in version strings (meta-version greater than 0)";
                     ok check-version($meta), "version is present and doesn't have an asterisk";


### PR DESCRIPTION
I think you meant to say that you want '::' and not hyphens.

I also added a patch to handle Gabor's request for a Travis CI example (#24).