### PR TITLE
List JSON::Fast in test deps

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -27,6 +27,7 @@
   ],
   "license": "Artistic-2.0",
   "test-depends": [
+    "JSON::Fast",
     "Test"
   ],
   "provides": {


### PR DESCRIPTION
Not 100% sure why this might be needed here since I think the dep is actually in META6, but I'm getting these failures:

```
===> Testing: Test::META:ver<0.0.14>:auth<github:jonathanstowe>
Testing with plugin: Zef::Service::Shell::prove+{<anon|1>}
# Failed test 'Can load "Test::META" ok'
# at t/010-use.t line 8
# ===SORRY!===
# Could not find JSON::Fast at line 4 in:
#     /home/zoffix/.zef/store/Test-META.git/695e911a075518d8f013dcf6013791849ee12039/lib
#     /home/zoffix/.zef/store/Test-META.git/695e911a075518d8f013dcf6013791849ee12039
#     /home/zoffix/.perl6
#     /home/zoffix/rakudo/install/share/perl6/site
#     /home/zoffix/rakudo/install/share/perl6/vendor
#     /home/zoffix/rakudo/install/share/perl6
#     CompUnit::Repository::AbsolutePath<82162448>
#     CompUnit::Repository::NQP<53496600>
#     CompUnit::Repository::Perl5<53496640>

```